### PR TITLE
fix paths

### DIFF
--- a/process/configuration/odense.json
+++ b/process/configuration/odense.json
@@ -4,7 +4,7 @@
     "geopackagePath": "odense_dk_2019_subset.gpkg",
     "graphmlName": "odense_dk_2019_10000m_pedestrian_osm_20190902.graphml",
     "graphmlProj_name": "odense_dk_2019_10000m_pedestrian_osm_20190902_proj_subset.graphml",
-    "folder": "./data",
+    "folder": "data",
     "parameters": {
         "samplePointsData_withoutNan": "samplePointsData_withoutNan",
         "samplePoints": "urban_sample_points",

--- a/process/readme.md
+++ b/process/readme.md
@@ -8,12 +8,12 @@ docker pull zacwang/global-indicator
 
 *On Windows* open a command prompt and run:
 ```
-docker run --rm -it -u 0 --name global-indicators -v %cd%:/home/jovyan/work zacwang/global-indicator /bin/bash
+docker run --rm -it -v "%cd%":/home/jovyan/work zacwang/global-indicator /bin/bash
 ```
 
 *On Mac/Linux* open a terminal window and run:
 ```
-docker run --rm -it -u 0 --name global-indicators -v "$PWD":/home/jovyan/work zacwang/global-indicator /bin/bash
+docker run --rm -it -v "$PWD":/home/jovyan/work zacwang/global-indicator /bin/bash
 ```
 
 #### run Python scripts. "true" indicates whether to use multiprocessing or not. 

--- a/process/readme.md
+++ b/process/readme.md
@@ -19,6 +19,8 @@ docker run --rm -it -u 0 --name global-indicators -v "$PWD":/home/jovyan/work za
 #### run Python scripts. "true" indicates whether to use multiprocessing or not. 
 #### Notice: Meloubrne has the largest number of sample points, which needs 13 GB memory for docker using 3 cpus.
 
+Change directories to `process` folder.
+
 ```
 python sv_sp.py odense.json true 
 ```

--- a/process/sv_setup_sp.py
+++ b/process/sv_setup_sp.py
@@ -276,6 +276,10 @@ def readGraphml(path, config):
     else:
         # else read original graphml and reproject it
         print('Start to reproject network')
+
+        # get the work directory
+        dirname = os.path.abspath('')
+
         graphml_path = os.path.join(dirname, config["folder"],
                                     config["graphmlName"])
         G = ox.load_graphml(graphml_path)

--- a/process/sv_sp.py
+++ b/process/sv_sp.py
@@ -25,8 +25,8 @@ if __name__ == '__main__':
     dirname = os.path.abspath('')
 
     # the configuration file should put in the "/configuration" folder located at the same folder as scripts
-    jsonFile = "./configuration/" + sys.argv[1]
-    jsonPath = os.path.join(dirname, 'process', jsonFile)
+    jsonFile = "configuration/" + sys.argv[1]
+    jsonPath = os.path.join(dirname, jsonFile)
     try:
         with open(jsonPath) as json_file:
             config = json.load(json_file)

--- a/win_docker_bash.bat
+++ b/win_docker_bash.bat
@@ -1,3 +1,3 @@
 docker pull zacwang/global-indicator:latest
 git pull
-docker run --rm -it -u 0 --name global-indicators -v "%cd%":/home/jovyan/work zacwang/global-indicator /bin/bash
+docker run --rm -it -v "%cd%":/home/jovyan/work zacwang/global-indicator /bin/bash

--- a/win_docker_bash.bat
+++ b/win_docker_bash.bat
@@ -1,0 +1,3 @@
+docker pull zacwang/global-indicator:latest
+git pull
+docker run --rm -it -u 0 --name global-indicators -v "%cd%":/home/jovyan/work zacwang/global-indicator /bin/bash


### PR DESCRIPTION
Currently if you're in bash in the `process` folder and run the documented command `python sv_sp.py odense.json true` you get the following error:

```
Failed to read json file.
[Errno 2] No such file or directory: '/home/jovyan/work/process/process/./configuration/odense.json'
Traceback (most recent call last):
  File "sv_sp.py", line 38, in <module>
    print('Start to process city: {}'.format(config["study_region"]))
NameError: name 'config' is not defined
```

The way the script assembles the path is broken, resulting in the nonexistent directory above.