### PR TITLE
Fixing the index length error

### DIFF
--- a/process/2_aggr_output_ind.ipynb
+++ b/process/2_aggr_output_ind.ipynb
@@ -114,7 +114,7 @@
     "input_folder = config['input_folder']\n",
     "\n",
     "# read city names from json\n",
-    "cities = list(sc.cities)\n",
+    "cities = [sc.cities[i]['cityname'] for i in range(len(sc.cities))]\n",
     "print('Cities:{}'.format(cities))"
    ]
   },

--- a/process/aggr.py
+++ b/process/aggr.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     folder = config['folder']
     input_folder = config['input_folder']
     # read city names from config
-    cities = list(sc.cities)
+    cities = [sc.cities[i]['cityname'] for i in range(len(sc.cities))]
     print('Cities:{}'.format(cities))
 
     # create the path of 'global_indicators_hex_250m.gpkg'


### PR DESCRIPTION
@nicholas-david get an error message when testing aggr.py scripts: 
![image](https://user-images.githubusercontent.com/46453772/83185092-72686800-a0f8-11ea-80b7-b8f6bb6faf78.png)

This pull request will fix this error by correcting the read cities name line of code:
From:
![image](https://user-images.githubusercontent.com/46453772/83185294-ba878a80-a0f8-11ea-8914-ab4a6ad3ad16.png)
to: 
![image](https://user-images.githubusercontent.com/46453772/83185328-c8d5a680-a0f8-11ea-97f9-ce504b057a65.png)
