### PR TITLE
amended requirements.txt to set pillow as >= 8.1.1 

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -8,10 +8,10 @@ dependencies:
   - affine=2.3.0=py_0
   - alabaster=0.7.12=py_0
   - argon2-cffi=20.1.0=py37h5e8e339_2
-  - astroid=2.5.3=py37h89c1867_0
+  - astroid=2.5.6=py37h89c1867_0
   - async_generator=1.10=py_0
   - attrs=20.3.0=pyhd3deb0d_0
-  - babel=2.9.0=pyhd3deb0d_0
+  - babel=2.9.1=pyh44b312d_0
   - backcall=0.2.0=pyh9f0ad1d_0
   - backports=1.0=py_2
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
@@ -27,7 +27,7 @@ dependencies:
   - c-ares=1.17.1=h7f98852_1
   - ca-certificates=2020.12.5=ha878542_0
   - cairo=1.16.0=h6cf1ce9_1008
-  - cartopy=0.18.0=py37h26456f9_13
+  - cartopy=0.19.0=py37h0c48da3_0
   - certifi=2020.12.5=py37h89c1867_1
   - cffi=1.14.5=py37hc58025e_0
   - cfitsio=3.470=h2e3daa1_7
@@ -43,6 +43,7 @@ dependencies:
   - curl=7.76.1=h979ede3_1
   - cycler=0.10.0=py_2
   - cython=0.29.23=py37hcd2ae1e_0
+  - dataclasses=0.8=pyhc8e2a94_1
   - decorator=5.0.7=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - descartes=1.1.0=py_4
@@ -77,7 +78,7 @@ dependencies:
   - importlib-metadata=4.0.1=py37h89c1867_0
   - inequality=1.0.0=py_0
   - ipykernel=5.5.3=py37h085eea5_0
-  - ipython=7.22.0=py37h085eea5_0
+  - ipython=7.23.0=py37h085eea5_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.6.3=pyhd3deb0d_0
   - isort=5.8.0=pyhd8ed1ab_0
@@ -123,7 +124,7 @@ dependencies:
   - libnghttp2=1.43.0=h812cca2_0
   - libopenblas=0.3.12=pthreads_hb3c22a3_1
   - libpng=1.6.37=h21135ba_2
-  - libpq=13.1=hfd2b0eb_2
+  - libpq=13.2=hfd2b0eb_2
   - libpysal=4.4.0=pyhd8ed1ab_0
   - librttopo=1.1.0=h1185371_6
   - libsodium=1.0.18=h36c2ea0_1
@@ -131,7 +132,7 @@ dependencies:
   - libspatialite=5.0.1=he52d314_3
   - libssh2=1.9.0=ha56f1ee_6
   - libstdcxx-ng=9.3.0=h6de172a_19
-  - libtiff=4.2.0=hdc55705_0
+  - libtiff=4.2.0=hdc55705_1
   - libuuid=2.32.1=h7f98852_1000
   - libwebp-base=1.2.0=h7f98852_2
   - libxcb=1.13=h7f98852_1003
@@ -142,6 +143,7 @@ dependencies:
   - mapclassify=2.4.2=pyhd8ed1ab_0
   - markupsafe=1.1.1=py37h5e8e339_3
   - matplotlib-base=3.4.1=py37hdd32ed1_0
+  - matplotlib-inline=0.1.2=pyhd8ed1ab_2
   - mccabe=0.6.1=py_1
   - memory_profiler=0.57.0=py_0
   - mercantile=1.2.1=pyhd8ed1ab_0
@@ -179,13 +181,13 @@ dependencies:
   - pcre=8.44=he1b5a44_0
   - pexpect=4.8.0=pyh9f0ad1d_2
   - pickleshare=0.7.5=py_1003
-  - pillow=8.1.1=py37h4600e1f_0
-  - pip=21.0.1=pyhd8ed1ab_0
+  - pillow=8.1.2=py37h4600e1f_1
+  - pip=21.1.1=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
   - pointpats=2.2.0=py_0
   - poppler=0.89.0=h2de54a5_5
   - poppler-data=0.4.10=0
-  - postgresql=13.1=h6303168_2
+  - postgresql=13.2=h6303168_2
   - proj=7.2.0=h277dcde_2
   - prometheus_client=0.10.1=pyhd8ed1ab_0
   - prompt-toolkit=3.0.18=pyha770c72_0
@@ -241,7 +243,7 @@ dependencies:
   - sphinx=3.5.4=pyh44b312d_0
   - sphinx_rtd_theme=0.5.2=pyhd8ed1ab_1
   - sphinxcontrib-applehelp=1.0.2=py_0
-  - sphinxcontrib-bibtex=2.1.4=pyhd8ed1ab_0
+  - sphinxcontrib-bibtex=2.2.0=pyhd8ed1ab_0
   - sphinxcontrib-devhelp=1.0.2=py_0
   - sphinxcontrib-htmlhelp=1.0.3=py_0
   - sphinxcontrib-jsmath=1.0.1=py_0
@@ -251,14 +253,14 @@ dependencies:
   - splot=1.1.3=pyhd8ed1ab_1
   - spreg=1.2.2=pyhd8ed1ab_0
   - spvcm=0.3.0=py_0
-  - sqlalchemy=1.4.10=py37h5e8e339_0
-  - sqlite=3.35.4=h74cdb3f_0
+  - sqlalchemy=1.4.13=py37h5e8e339_0
+  - sqlite=3.35.5=h74cdb3f_0
   - statsmodels=0.12.2=py37h902c9e0_0
   - sympy=1.8=py37h89c1867_0
   - terminado=0.9.4=py37h89c1867_0
   - testpath=0.4.4=py_0
   - threadpoolctl=2.1.0=pyh5ca1d4c_0
-  - tiledb=2.2.7=h91fcb0e_0
+  - tiledb=2.2.8=h91fcb0e_0
   - tk=8.6.10=h21135ba_1
   - tobler=0.7.0=pyhd8ed1ab_0
   - toml=0.10.2=pyhd8ed1ab_0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -16,7 +16,7 @@ numexpr == 2.7.*
 numpy == 1.17.*
 osmnx == 0.14.*
 pandana == 0.4.*
-pillow == 8.1.1
+pillow >= 8.1.1
 pip
 psycopg2 == 2.8.*
 pylint

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -16,7 +16,7 @@ numexpr == 2.7.*
 numpy == 1.17.*
 osmnx == 0.14.*
 pandana == 0.4.*
-pillow >= 8.1.1
+pillow >= 8.1.1,<8.2.0
 pip
 psycopg2 == 2.8.*
 pylint


### PR DESCRIPTION
Closes #116 

amended requirements.txt to set pillow as >= 8.1.1  (ie. instead of ==8.1.1).  This was done because to set this as 8.1.* or 8.* would mean that versions 8.1.0 or lower could be used, which would result in a security vulnerability warning on our git home page (which initially alerted me to the issue).