### PR TITLE
removed between city walkability

### DIFF
--- a/process/aggr.py
+++ b/process/aggr.py
@@ -68,8 +68,8 @@ if __name__ == "__main__":
     # calc_hexes_zscore_walk take the zsocres of the hex-level indicators
     # generated using calc_hexes_pct_sp_indicators function to create daily
     # living and walkability scores
-    print("\nCalculate hex-level indicators zscores relative to all cities.")
-    sa.calc_hexes_zscore_walk(gpkg_output_hex, cities)
+    #print("\nCalculate hex-level indicators zscores relative to all cities.")
+    #sa.calc_hexes_zscore_walk(gpkg_output_hex, cities)
     
     print("\nCreate combined layer of all cities hex grids, to facilitate grouped analyses and mapping")
     sa.combined_city_hexes(gpkg_inputs, gpkg_output_hex, cities)
@@ -84,9 +84,7 @@ if __name__ == "__main__":
     # the spatial distribution of key walkability measures (regardless of population distribution)
     # as per discussion here: https://3.basecamp.com/3662734/buckets/11779922/messages/2465025799
     extra_unweighted_vars = ['local_nh_population_density','local_nh_intersection_density','local_daily_living',
-      'local_walkability',
-      'all_cities_z_nh_population_density','all_cities_z_nh_intersection_density','all_cities_z_daily_living',
-      'all_cities_walkability']
+      'local_walkability']
     for i, gpkg_input in enumerate(tqdm(gpkg_inputs)):
         if i==0:
             all_cities_combined = sa.calc_cities_pop_pct_indicators(gpkg_output_hex, cities[i], 

--- a/process/setup_config.py
+++ b/process/setup_config.py
@@ -100,10 +100,10 @@ field_lookup = {
   'sp_access_pt_gtfs_freq_30_score'        :{'hex':f'pct_access_{accessibility_distance}m_pt_gtfs_freq_30_score','all':''},
   'sp_access_pt_gtfs_freq_20_score'        :{'hex':f'pct_access_{accessibility_distance}m_pt_gtfs_freq_20_score','all':''},
   'sp_access_pt_any_score'                 :{'hex':f'pct_access_{accessibility_distance}m_pt_any_score','all':''},
-  'sp_local_nh_avg_pop_density'             :{'hex': 'local_nh_population_density'   ,'all':"all_cities_z_nh_population_density"},
-  'sp_local_nh_avg_intersection_density'    :{'hex': 'local_nh_intersection_density' ,'all':"all_cities_z_nh_intersection_density"},
-  'sp_daily_living_score'                   :{'hex': 'local_daily_living'            ,'all':"all_cities_z_daily_living"},
-  'sp_walkability_index'                    :{'hex': 'local_walkability'             ,'all':"all_cities_walkability"}
+  'sp_local_nh_avg_pop_density'             :{'hex': 'local_nh_population_density'   ,'all':""},
+  'sp_local_nh_avg_intersection_density'    :{'hex': 'local_nh_intersection_density' ,'all':""},
+  'sp_daily_living_score'                   :{'hex': 'local_daily_living'            ,'all':""},
+  'sp_walkability_index'                    :{'hex': 'local_walkability'             ,'all':""}
 }
 
 fieldNames_from_samplePoint   = [x for x in field_lookup if field_lookup[x]['hex']!='']
@@ -138,7 +138,6 @@ city_fieldNames = basic_attributes[1:] \
                      .replace('pct','pop_pct') \
                      .replace('local','pop') \
                      .replace('_z_','_pop_z_') \
-                     .replace('all_cities_walkability','all_cities_pop_walkability') \
                          for x in hex_fieldNames if x not in basic_attributes]
 
 gpkgNames = {}


### PR DESCRIPTION
This fix addresses issue #136 by removing the 'between city' walkability comparisons, which as currently implemented are relative to 'average' of the set of cities being studied.  This was a fixed set of 25 cities in our preliminary study, but now we are looking to calculate for more cities 'relative to average' is an unstable comparions.

We discussed several approaches, including

- use the 25 city average as an empirical 'average city benchmark' --- ie. this become the new fixed reference point for future study regions and time points  (easy to implement, but may not be a 'good' comparison; empirical, but arbitrary)
- remove between city walkability comparison (relatively easy; and comparisons could be made seperately, or reintroduced later once we think about this more)
- remove walkability index altogether, until we develop updated methods (do-able, but more involved, and means within-city equities in the traditional walkability metrics couldn't be visualised)

This pull request is for the second option listed above --- removing the between city comparison.  We could go further, but this is a starting point, and I have verified that it works (running the code for Ghent, in preparation for their updated population analysis).