### PR TITLE
added in the option to load external data to represent intersections…

### DIFF
--- a/process/configuration/regions/example_ES_Las_Palmas_2023.yml
+++ b/process/configuration/regions/example_ES_Las_Palmas_2023.yml
@@ -74,6 +74,10 @@ network:
     polygon_iteration: false
     connection_threshold:
     intersection_tolerance: 12
+    # intersections:
+        # data: network_data/your_intersection_data.geojson
+        # citation: 'Provider of your intersection data.  YYYY.  Name of your intersection data. https://source-url-for-your-data.place'
+        # note: 'Uncomment this configuration section to optionally specify an external dataset of intersections.  Otherwise, these are derived using OpenStreetMap and OSMnx using the intersection_tolerance parameter.  If providing intersection data, you can modify this note for it to be included in the metadata, or remove it.
 urban_region:
     name: "Global Human Settlements urban centres: 2015 (EU JRC, 2019; Las Palmas de Gran Canaria only)"
     data_dir: "urban_regions/Example/Las Palmas de Gran Canaria - GHS_STAT_UCDB2015MT_GLOBE_R2019A_V1_2.gpkg"


### PR DESCRIPTION
… as per #302, and related to #158

This means that people have the option to use their own intersection data, or take the OpenStreetMap nodes or consolidated intersections and conduct further cleaning themselves if they find its required for their study region.

In doing this, I added in a function within the ghsci.Region object to support loading data using ogr2ogr into the region database.  The study region creation script was refactored to make use of this, and remove modules that are no longer used.