### PR TITLE
improved warning message for attempt to generate report for language …

### DIFF
--- a/process/subprocesses/_utils.py
+++ b/process/subprocesses/_utils.py
@@ -164,6 +164,8 @@ def postgis_to_geopackage(gpkg, db_host, db_user, db, db_pwd, tables):
 def generate_report_for_language(
     r, language, indicators, policies, template=None, cmap=None,
 ):
+    from subprocesses.ghsci import get_languages
+
     if cmap is None:
         from subprocesses.batlow import batlow_map as cmap
 
@@ -177,6 +179,12 @@ def generate_report_for_language(
     font = get_and_setup_font(language, r.config)
     # Generate resources
     print(f'\n{language}')
+    if phrases is None:
+        print(
+            f'  - Skipped: {language} does not appear to have been translated and added to _report_configuration.xlsx.  If you would like to assist with translation of this language, please add an issue at https://github.com/global-healthy-liveable-cities/global-indicators/issues.\n\nThe validated languages available for reporting are:\n{get_languages().index.tolist()}',
+        )
+        return None
+
     if phrases['validated'] == 1:
         # instantiate template
         if template is None:
@@ -214,7 +222,7 @@ def generate_report_for_language(
             print(capture_return)
     else:
         print(
-            '  - Skipped: This language has not been flagged for export in _report_configuration.xlsx (some languages such as Tamil may have features to their writing that currently are not supported, such as Devaganari conjuncts; perhaps for this reason it has not been flagged for export, or otherwise it has not been fully configured).',
+            '  - Skipped: A preliminary translation has been made for this language in _report_configuration.xlsx, however it has not yet been validated for publication (validation = 0; when it has been validated, this will be changed to validated = 1).  If you have concerns or would like to assist with validation of this or another language, please add an issue at https://github.com/global-healthy-liveable-cities/global-indicators/issues.',
         )
 
 

--- a/process/tests/tests.py
+++ b/process/tests/tests.py
@@ -48,8 +48,7 @@ class tests(unittest.TestCase):
 
     def test_3_load_example_region(self):
         """Load example region."""
-        codename = 'example_ES_Las_Palmas_2023'
-        r = ghsci.Region(codename)
+        r = ghsci.example()
 
     def test_4_create_db(self):
         """Load example region."""
@@ -59,14 +58,12 @@ class tests(unittest.TestCase):
 
     def test_5_example_analysis(self):
         """Analyse example region."""
-        codename = 'example_ES_Las_Palmas_2023'
-        r = ghsci.Region(codename)
+        r = ghsci.example()
         r.analysis()
 
     def test_6_example_generate(self):
         """Generate resources for example region."""
-        codename = 'example_ES_Las_Palmas_2023'
-        r = ghsci.Region(codename)
+        r = ghsci.example()
         r.generate()
 
     def test_7_sensitivity(self):
@@ -105,6 +102,18 @@ class tests(unittest.TestCase):
             index=False,
         )
         r.compare(comparison)
+
+    def test_8_example_generate_report_in_another_language(self):
+        """Generate resources for example region."""
+        r = ghsci.example()
+        r.generate_report('Spanish - Latin America')
+
+    def test_8_example_generate_report_in_another_language_that_does_not_exist(
+        self,
+    ):
+        """Generate resources for example region."""
+        r = ghsci.example()
+        r.generate_report('FishFish - Unicorns')
 
 
 def calculate_line_endings(path):


### PR DESCRIPTION
…that hasn't been validated, and made a nicer warning message rather than crash if a language that doesn't exist is attempted (#431).  I added a test for this, and updated tests run for github actions to use ghsci.example() (although ghsci.Region(codename) is still used in some tests, so is tested also)