### PR TITLE
Update Figshare upload action to load latest release

### DIFF
--- a/.github/workflows/figshare.yml
+++ b/.github/workflows/figshare.yml
@@ -9,7 +9,7 @@ jobs:
         id: release
         uses: creesch/github-latest-release-zip@v0.1.1
         with:
-          owner: global-healthy-liveable-cities
+          owner: healthysustainablecities
           repo: global-indicators
           downloadPath: "output"
       - uses: figshare/github-upload-action@v1.1


### PR DESCRIPTION
This hadn't been modified from the old global-health-liveable-cities account to the healthysustainablecities account, so hasn't worked for some time.  Should work now!