### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/figshare.yml
+++ b/.github/workflows/figshare.yml
@@ -1,5 +1,7 @@
 name: Upload to Figshare
 on: [release]
+permissions:
+  contents: read
 jobs:
   upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/healthysustainablecities/global-indicators/security/code-scanning/2](https://github.com/healthysustainablecities/global-indicators/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's actions, it appears to only need read access to repository contents (`contents: read`). This will ensure that the `GITHUB_TOKEN` cannot perform unintended write operations on the repository.

The `permissions` block will be added at the root of the workflow file, applying to all jobs in the workflow. This is the most efficient approach since the workflow only contains one job (`upload`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
