### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   pull_request: { branches: main }
   push: { branches: main }


### PR DESCRIPTION
Potential fix for [https://github.com/healthysustainablecities/global-indicators/security/code-scanning/1](https://github.com/healthysustainablecities/global-indicators/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to restrict the `GITHUB_TOKEN` permissions to the minimum required. Based on the workflow's operations, it primarily needs `contents: read` to check out the code. No other permissions appear necessary unless the workflow is extended to perform additional actions. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
