### PR TITLE
correcting version number in requirements

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -109,7 +109,7 @@ nbconvert==7.16.6
 nbformat==5.10.4
 nest_asyncio==1.6.0
 networkx==3.6.1
-nicegui==0.0.0.post287.dev0+888eb98
+nicegui==3.4.0
 notebook_shim==0.2.4
 numexpr==2.14.1
 numpy==1.26.4


### PR DESCRIPTION
Nicegui was updated to v3.4.0, but the version number listed in requirements.txt was recorded incorrectly as 0.0.0.

e.g. 

```
>>> import nicegui
>>> nicegui.__version__
'0.0.0.post287.dev0+888eb98'
```

So, that's not true --- its actually 3.4.0 (a version released yesterday to address dependabot alerts on their side, but apparently, the version number recorded in the software pushed to conda was not correct).

So this pull request is updating the requirements.txt log file to reflect the actual version being used so our own dependabot alerts are correctly resolved.