### PR TITLE
implemented r.indicator_summary() function and incremented version

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 GHSCI_VERSION=4.15.0
-GHSCI_RELEASE=4.16.1
+GHSCI_RELEASE=4.16.2
 B='$(tput bold)' # Bold text
 N='$(tput sgr0)' # Normal text
 INSTRUCTIONS="\nCalculate and report on spatial and policy indicators for healthy, sustainable cities worldwide in four steps: configure, analysis, generate and compare.\n\nThe software can be run in different ways.  For use in your web browser, type and enter:\n  - ${B}ghsci${N} (to launch an interactive app at http://localhost:8080)\n  - ${B}lab${N} (to view an example Python notebook, or create your own, within Jupyter Lab)\n\nTo view these instructions again with additional guidance on commandline usage, enter: ${B}help${N}\n\nTo exit, type and enter: ${B}exit${N}\n\nFor full details consult our software guide:\n${B}https://healthysustainablecities.github.io/software/${N}\n\n"

--- a/process/generate.py
+++ b/process/generate.py
@@ -17,7 +17,11 @@ from subprocesses.ghsci import (
 
 
 def export_indicators(r, gpkg=True, csv=True):
-    custom_aggregations = r.config.pop('custom_aggregations', {})
+    # read, never popped: the data dictionary compiled later in generate()
+    # consults this to document the custom aggregation output columns, and a
+    # configuration that quietly empties itself as it is used cannot be
+    # consulted twice
+    custom_aggregations = r.config.get('custom_aggregations') or {}
     tables = [f'indicators_{x}' for x in custom_aggregations] + [
         r.config['city_summary'],
         r.config['grid_summary'],

--- a/process/subprocesses/_12_aggregation.py
+++ b/process/subprocesses/_12_aggregation.py
@@ -342,6 +342,46 @@ def qualify_keep_columns(keep_columns, id: str, boundary_columns: dict) -> str:
     return f'{columns},'
 
 
+def resolve_output_names(indicators: dict, agg_kind: str, weighted: bool):
+    """Map each source indicator column to its output name and scale.
+
+    Returns a list of (source_column, output_column, scale) tuples, where
+    scale is the factor by which the source value is multiplied.
+
+    Output naming does not depend on which variable was used as the
+    weight.  A weighted estimate always takes the region level variable
+    name (pop_walkability) and an unweighted one the neighbourhood
+    variable name (local_walkability), so that every aggregation of a
+    region reports the same indicators under the same names and any two
+    may be compared row for row.  The weight that was applied is reported
+    as pop_est, and recorded in the region's parameters; it is not
+    encoded in the column names.
+
+    Sample point variables are proportions, so the accessibility measures
+    among them are scaled to percentages, as they are for the population
+    grid.  Areal sources have already been scaled and are not rescaled.
+
+    The sample point, neighbourhood and region level variable lists are
+    positionally parallel; this is the only place that relies on that.
+    """
+    sample_point_variables = indicators['output']['sample_point_variables']
+    neighbourhood_variables = indicators['output']['neighbourhood_variables']
+    city_variables = indicators['output']['city_variables']
+    if agg_kind == 'point':
+        return [
+            (
+                sp,
+                nb,
+                100.0 if nb.startswith('pct_') else 1.0,
+            )
+            for sp, nb in zip(sample_point_variables, neighbourhood_variables)
+        ]
+    return [
+        (nb, cy if weighted else nb, 1.0)
+        for nb, cy in zip(neighbourhood_variables, city_variables)
+    ]
+
+
 def resolve_weight(r: ghsci.Region, weight, boundaries, agg_source, agg_kind):
     """
     Locate a configured weight variable and decide how it should be applied.
@@ -416,14 +456,6 @@ def custom_aggregation(r: ghsci.Region, indicators: dict) -> list:
     """
     processed_aggs = []
     plans = []
-    name_mapping = {
-        z[0]: z[1]
-        for z in zip(
-            indicators['output']['sample_point_variables'],
-            indicators['output']['neighbourhood_variables'],
-        )
-        if z[0] != z[1]
-    }
     # The aggregation below matches sample points / grid cells (and network
     # intersections) against each boundary with ST_Intersects / ST_DWithin.
     # grid_summary, point_summary and the (OSMnx) intersections table are all
@@ -490,16 +522,11 @@ def custom_aggregation(r: ghsci.Region, indicators: dict) -> list:
         else:
             if agg_source in ['point', 'grid']:
                 agg_kind = agg_source
-                if agg_source == 'point':
-                    count_units = 'urban_sample_point_count'
-                    indicator_list = indicators['output'][
-                        'sample_point_variables'
-                    ]
-                else:
-                    count_units = 'grid_count'
-                    indicator_list = indicators['output'][
-                        'neighbourhood_variables'
-                    ]
+                count_units = (
+                    'urban_sample_point_count'
+                    if agg_source == 'point'
+                    else 'grid_count'
+                )
                 agg_source = r.config[f'{agg_source}_summary']
             elif agg_source in processed_aggs:
                 # unclear if this will always be appropriate; may need customisation
@@ -508,9 +535,6 @@ def custom_aggregation(r: ghsci.Region, indicators: dict) -> list:
                     f"indicators_{agg_source.replace(' ', '_').lower()}"
                 )
                 count_units = 'area_count'
-                indicator_list = indicators['output'][
-                    'neighbourhood_variables'
-                ]
             else:
                 print(
                     f'    Aggregating source {agg_source} could not be identified; skipping.',
@@ -584,24 +608,7 @@ def custom_aggregation(r: ghsci.Region, indicators: dict) -> list:
             else:
                 share = ''
             agg_weight = f"""COALESCE(SUM(s."{weight_column}"{share}),0)"""
-            # pop_est is the standard population weight; use the neighbourhood
-            # → city name mapping so columns match indicators_region exactly
-            # (e.g. local_nh_population_density → pop_nh_pop_density).
-            output_prefix = (
-                'pop' if weight_column == 'pop_est' else weight_column
-            )
-            neighbourhood_to_city = (
-                {
-                    nb: cy
-                    for nb, cy in zip(
-                        indicators['output']['neighbourhood_variables'],
-                        indicators['output']['city_variables'],
-                    )
-                }
-                if weight_column == 'pop_est'
-                else {}
-            )
-            # using population weighting
+            # using weighting
             # if there are zero weights the indicator is null
             # else, calculate the value of the weighted indicator
             weighting = '''
@@ -615,32 +622,32 @@ def custom_aggregation(r: ghsci.Region, indicators: dict) -> list:
             agg_formula = ','.join(
                 [
                     weighting.format(
-                        i=i,
+                        i=source,
                         weight=weight_column,
                         share=share,
-                        col=neighbourhood_to_city.get(
-                            i,
-                            f'{output_prefix}_{i}',
-                        ),
+                        col=output,
                     )
-                    for i in indicator_list
+                    for source, output, _ in resolve_output_names(
+                        indicators,
+                        agg_kind,
+                        True,
+                    )
                 ],
             )
             # Mirror the city summary: append extra_unweighted_vars as plain
-            # unweighted means alongside their population-weighted counterparts.
-            if weight_column == 'pop_est':
-                extra = [
-                    v
-                    for v in indicators['output'].get(
-                        'extra_unweighted_vars',
-                        [],
-                    )
-                    if v in indicator_list
-                ]
-                if extra:
-                    agg_formula += ', ' + ', '.join(
-                        f'\n    AVG(s."{v}"::float8) AS "{v}"' for v in extra
-                    )
+            # unweighted means alongside their weighted counterparts, so that
+            # the two may be distinguished.  Weighted estimates have been
+            # renamed to the region level variable names, so these do not
+            # collide with them.
+            extra = [
+                v
+                for v in indicators['output'].get('extra_unweighted_vars', [])
+                if v in indicators['output']['neighbourhood_variables']
+            ]
+            if extra and agg_kind != 'point':
+                agg_formula += ', ' + ', '.join(
+                    f'\n    AVG(s."{v}"::float8) AS "{v}"' for v in extra
+                )
         else:
             # Either no usable weight, or the weight belongs to the boundary
             # (a point source), in which case it is reported as the boundary's
@@ -648,8 +655,12 @@ def custom_aggregation(r: ghsci.Region, indicators: dict) -> list:
             agg_weight = weight_column
             agg_formula = ','.join(
                 [
-                    f'''\n    {100.0 if name_mapping.get(i, '').startswith('pct') else 1.0} * AVG(s."{i}"::float8) AS "{name_mapping.get(i, "avg_" + i)}"'''
-                    for i in indicator_list
+                    f'''\n    {scale} * AVG(s."{source}"::float8) AS "{output}"'''
+                    for source, output, scale in resolve_output_names(
+                        indicators,
+                        agg_kind,
+                        False,
+                    )
                 ],
             )
         # Intersections are counted against the boundary using a lateral

--- a/process/subprocesses/data_dictionary.py
+++ b/process/subprocesses/data_dictionary.py
@@ -77,6 +77,7 @@ UNITS_VOCABULARY = {
     'intersections_per_sqkm': ('count per km²', 'rate'),
     'urban_sample_point_count': ('count', 'count'),
     'grid_count': ('count', 'count'),
+    'area_count': ('count', 'count'),
     'local_nh_population_density': ('persons per km²', 'mean'),
     'pop_nh_pop_density': ('persons per km²', 'mean'),
     'sp_local_nh_avg_pop_density': ('persons per km²', 'value'),
@@ -352,6 +353,11 @@ BASE_VOCABULARY = {
     'grid_count': (
         'Analytical statistics',
         'Count of population grid cells associated with this area',
+    ),
+    'area_count': (
+        'Analytical statistics',
+        'Count of areas of the aggregation summarised here that are '
+        'associated with this area',
     ),
     'grid_id': (
         'Analytical statistics',
@@ -1632,6 +1638,7 @@ def reference_data_dictionary():
         ('grid_id', 'grid, sample point'),
         ('point_id', 'sample point'),
         ('grid_count', 'custom areas'),
+        ('area_count', 'custom areas'),
     ]:
         add_concrete(variable, scale)
     # parameters: placeholder + description, then (for [destination]) the

--- a/process/subprocesses/ghsci.py
+++ b/process/subprocesses/ghsci.py
@@ -1966,6 +1966,48 @@ class Region:
         result = compare_resources(a=reference, b=self, save=save)
         return result
 
+    def indicator_summary(
+        self,
+        scales='region',
+        by=None,
+        variables=None,
+        max_columns=12,
+        decimals=None,
+        labels=None,
+        include_region=True,
+        markdown=False,
+        save=False,
+        display=True,
+    ):
+        """Summarise indicators as a tidy table with plain-language labels.
+
+        Rows are output variables described using the data dictionary and
+        grouped by category; columns are this region's summary, followed by
+        each area of any additional scales requested.  Scales may be named
+        by alias ('region', 'grid', 'sample points'), by custom aggregation
+        name, or by table name; the region summary heads the columns
+        unless include_region is False.  Set markdown=True to return markdown, and
+        save=True (or a path) to write the result.  For example:
+        r.indicator_summary()
+        r.indicator_summary('region', ['suburbs', 'meshblocks'])
+        r.indicator_summary('suburbs', markdown=True, save=True)
+        """
+        from indicator_summary import indicator_summary as summarise
+
+        return summarise(
+            self,
+            scales=scales,
+            by=by,
+            variables=variables,
+            max_columns=max_columns,
+            decimals=decimals,
+            labels=labels,
+            include_region=include_region,
+            markdown=markdown,
+            save=save,
+            display=display,
+        )
+
     def drop(self, table=''):
         """Attempt to drop results for this study region.  A specific table to drop may be given as an argument, and if no argument is provided an attempt will be made to drop this study region's database."""
         if table == '':
@@ -3896,6 +3938,7 @@ region_functions = {
     'retrieving data': {
         'description': 'Additional functions for retrieving specific data following analysis:',
         'functions': [
+            'indicator_summary',
             'get_tables',
             'get_df',
             'get_gdf',

--- a/process/subprocesses/ghsci.py
+++ b/process/subprocesses/ghsci.py
@@ -1986,8 +1986,9 @@ class Region:
         each area of any additional scales requested.  Scales may be named
         by alias ('region', 'grid', 'sample points'), by custom aggregation
         name, or by table name; the region summary heads the columns
-        unless include_region is False.  Set markdown=True to return markdown, and
-        save=True (or a path) to write the result.  For example:
+        unless include_region is False.  Set markdown=True to return
+        markdown, and save=True (or a path) to write the result.  For
+        example:
         r.indicator_summary()
         r.indicator_summary('region', ['suburbs', 'meshblocks'])
         r.indicator_summary('suburbs', markdown=True, save=True)

--- a/process/subprocesses/indicator_summary.py
+++ b/process/subprocesses/indicator_summary.py
@@ -1,0 +1,1000 @@
+"""Summarise a region's indicators as a tidy, labelled table.
+
+Presents output variables as rows, described in plain language using the
+data dictionary and grouped by category, with one column per area: the
+region summary first, followed by each area of any additional scales
+requested (custom aggregations such as suburbs or meshblocks, or the
+grid and sample point summaries).
+
+This differs from compare(), which contrasts the city-scale summaries of
+two or more study regions using raw variable names: this describes a
+single region at whatever scales it was aggregated to, rounds each value
+according to what it measures, prints the result, and can emit markdown.
+
+The region is duck typed (as in data_dictionary), so only get_tables(),
+get_df(), config and codename are required.  Called as:
+
+    r.indicator_summary()
+    r.indicator_summary('region', ['suburbs', 'meshblocks'])
+    r.indicator_summary('suburbs', markdown=True, save=True)
+
+It may also be run on the commandline from the process folder, e.g.
+    /env/bin/python subprocesses/indicator_summary.py <codename> suburbs
+"""
+
+import os
+import re
+import sys
+import textwrap
+from datetime import datetime
+
+import data_dictionary
+import pandas as pd
+
+# Aliases for the standard output scales, mapped to the region
+# configuration key naming each table.
+SCALE_ALIASES = {
+    'region': 'city_summary',
+    'city': 'city_summary',
+    'city_summary': 'city_summary',
+    'region_summary': 'city_summary',
+    'grid': 'grid_summary',
+    'grid_summary': 'grid_summary',
+    'population_grid': 'grid_summary',
+    'sample_points': 'point_summary',
+    'sample_point': 'point_summary',
+    'points': 'point_summary',
+    'point': 'point_summary',
+    'point_summary': 'point_summary',
+}
+
+# The names that identify the region summary, whichever way it is asked
+# for; a raw table name is included, as that is the name it is exported
+# and reported under.
+CITY_ALIASES = {
+    alias for alias, key in SCALE_ALIASES.items() if key == 'city_summary'
+} | {'indicators_region'}
+
+# Identifiers that number rows without naming them; unusable as column
+# headings, and skipped when looking for a label field.
+SURROGATE_IDS = {
+    'fid',
+    'gid',
+    'grid_id',
+    'id',
+    'index',
+    'ogc_fid',
+    'osm_id',
+    'point_id',
+}
+
+# The region summary inherits quoted, display-style column names from
+# the urban covariates, where every other scale uses the lower case
+# name for the same measure.  Reported as one row each, so that a
+# region and its areas can be read across; the data dictionary lists
+# both spellings of each of these against identical units.
+VARIABLE_SYNONYMS = {
+    'Area (sqkm)': 'area_sqkm',
+    'Population estimate': 'pop_est',
+    'Population per sqkm': 'pop_per_sqkm',
+    'Intersections': 'intersection_count',
+    'Intersections per sqkm': 'intersections_per_sqkm',
+}
+
+# Codes and identifiers retained from boundary data are numbers that
+# are not quantities: a postcode must not be grouped into thousands.
+CODE_PATTERN = re.compile(
+    r'(^|_)(id|ids|cod|codigo|code\d*|postal|postcode|zip|fid|uid)(\d*)(_|$)',
+    re.IGNORECASE,
+)
+
+# Columns preferred for ordering areas when a scale must be capped,
+# with the short phrase used to report the ordering that was applied.
+WEIGHT_COLUMNS = {
+    'pop_est': 'population estimate',
+    'urban_sample_point_count': 'sample point count',
+    'grid_count': 'grid cell count',
+    'area_count': 'area count',
+}
+
+
+def _norm(name) -> str:
+    """Normalise a scale name for case and separator insensitive matching."""
+    return re.sub(r'[\s\-]+', '_', str(name).strip().lower())
+
+
+def normalise_scales(scales, by=None, include_region=True) -> list:
+    """Flatten scale arguments to an ordered, de-duplicated list of names.
+
+    Accepts a string, a list, or a list containing lists, so that a
+    primary scale and a list of additional scales may be given
+    positionally, as in
+    indicator_summary('region', ['suburbs', 'meshblocks']).
+
+    The region summary is the reference every area is read against, so
+    it heads the columns unless it was named in some other position, or
+    include_region is False.
+    """
+    names = []
+    for argument in (scales, by):
+        if argument is None:
+            continue
+        if isinstance(argument, (str, bytes)):
+            names.append(argument)
+            continue
+        try:
+            items = list(argument)
+        except TypeError:
+            names.append(argument)
+            continue
+        for item in items:
+            if isinstance(item, (str, bytes)) or not hasattr(item, '__iter__'):
+                names.append(item)
+            else:
+                names.extend(item)
+    ordered = []
+    for name in names:
+        if str(name).strip() and name not in ordered:
+            ordered.append(name)
+    if not ordered:
+        return ['region']
+    if include_region and not any(
+        _norm(name) in CITY_ALIASES for name in ordered
+    ):
+        ordered.insert(0, 'region')
+    return ordered
+
+
+def scale_options(config, tables) -> list:
+    """List the scale names that could be requested for a region."""
+    options = ['region', 'grid', 'sample points']
+    options.extend(list((config.get('custom_aggregations') or {}).keys()))
+    options.extend(
+        [
+            t
+            for t in tables
+            if t.startswith('indicators_') and t not in options
+        ],
+    )
+    return options
+
+
+def resolve_scales(config, tables, names) -> list:
+    """Resolve requested scale names to output tables.
+
+    Returns one descriptor per resolved scale, in the order requested,
+    de-duplicated by table: a custom aggregation may also be the
+    configured population grid, in which case 'grid' and that
+    aggregation's own name identify the same table.
+    """
+    custom = {}
+    for aggregation in (config.get('custom_aggregations') or {}).keys():
+        table = f"indicators_{aggregation.replace(' ', '_').lower()}"
+        for key in {_norm(aggregation), _norm(table)}:
+            custom[key] = (aggregation, table)
+    resolved = []
+    seen = set()
+    for name in names:
+        key = _norm(name)
+        aggregation = None
+        if key in SCALE_ALIASES:
+            table = config.get(SCALE_ALIASES[key])
+            kind = SCALE_ALIASES[key].split('_')[0]
+        elif key in custom:
+            aggregation, table = custom[key]
+            kind = 'custom'
+        elif str(name) in tables or key in tables:
+            table = str(name) if str(name) in tables else key
+            kind = 'table'
+        else:
+            print(
+                f"\nNote: the scale '{name}' was not recognised, and has been "
+                'skipped.  Scales may be named by alias, by custom '
+                'aggregation name, or by table name; this region has: '
+                f'{", ".join(scale_options(config, tables))}',
+            )
+            continue
+        if table is None or table in seen:
+            continue
+        seen.add(table)
+        resolved.append(
+            {
+                'name': str(name),
+                'table': table,
+                'kind': kind,
+                'aggregation': aggregation,
+            },
+        )
+    return resolved
+
+
+def resolve_label_column(columns, id_column=None, keep_columns=None):
+    """Return the column whose values best name each area.
+
+    The aggregation SQL selects the configured identifier unquoted, so
+    PostgreSQL folds it to lower case (a configured 'SAL_NAME21' is the
+    column 'sal_name21'); matching is therefore case insensitive.
+    Surrogate identifiers number rows rather than naming them, so a
+    retained boundary attribute is preferred where one is available.
+    """
+    columns = list(columns)
+    lookup = {str(column).lower(): column for column in columns}
+    candidates = []
+    if id_column:
+        candidates.append(str(id_column))
+    candidates.extend(
+        [c.strip() for c in str(keep_columns or '').split(',') if c.strip()],
+    )
+    for candidate in candidates:
+        key = candidate.lower()
+        if key in lookup and key not in SURROGATE_IDS:
+            return lookup[key]
+    for candidate in candidates:
+        if candidate.lower() in lookup:
+            return lookup[candidate.lower()]
+    for key in lookup:
+        if key in SURROGATE_IDS:
+            return lookup[key]
+    return columns[0] if columns else None
+
+
+def disambiguate(labels, unnamed='(unnamed)') -> list:
+    """Return unique, printable text labels, numbering any duplicates."""
+    seen = {}
+    unique = []
+    for label in labels:
+        try:
+            missing = label is None or pd.isna(label)
+        except (TypeError, ValueError):
+            missing = False
+        text = unnamed if missing else str(label).strip()
+        if text == '':
+            text = unnamed
+        seen[text] = seen.get(text, 0) + 1
+        unique.append(text if seen[text] == 1 else f'{text} ({seen[text]})')
+    return unique
+
+
+def _adaptive_decimals(magnitude):
+    """Decimal places for a quantity whose units could not be resolved."""
+    if magnitude >= 1000:
+        return (0, True)
+    if magnitude >= 100:
+        return (1, False)
+    if magnitude >= 0.01 or magnitude == 0:
+        return (2, False)
+    return (4, False)
+
+
+def decimals_for(units, statistic, number) -> tuple:
+    """Return (decimal places, thousands separator) for a measurement.
+
+    Driven by the units and statistic the data dictionary reports for a
+    variable, so that regionally customised variables round correctly
+    without curated entries.  Trailing zeros are deliberately retained,
+    so that values in a column align on the decimal point.
+    """
+    units = str(units or '')
+    statistic = str(statistic or '')
+    magnitude = abs(number)
+    if statistic == 'category' or units in ('year', 'class 1-5'):
+        return (0, False)
+    if units.startswith('ordered class'):
+        return (0, False)
+    if units == 'percent':
+        return (1, False)
+    if units == 'metres':
+        return (0, True)
+    if 'per km' in units:
+        return (0, True) if magnitude >= 1000 else (1, True)
+    # area, tested before the count and sum statistics below: an area is
+    # summed over an aggregation, but is not a whole number
+    if units.startswith('km'):
+        return (1, True) if magnitude >= 100 else (2, True)
+    if units.startswith(('index', 'score', 'proportion', 'ratio')):
+        return (2, False)
+    if units.startswith(('degrees', 'deaths')):
+        return (1, False)
+    if units in ('persons', 'count') or statistic in ('count', 'sum'):
+        # a counted total is whole; an average of counts is not
+        return (0, True) if statistic in ('count', 'sum') else (1, True)
+    return _adaptive_decimals(magnitude)
+
+
+def format_value(variable, value, na_rep='', decimals=None) -> str:
+    """Format one value for display, rounded according to what it measures.
+
+    Missing values are reported as na_rep.  Values arrive from a
+    pyarrow backed frame, where a null is pd.NA rather than a float
+    nan: pd.NA is not an instance of float, and truth testing it
+    raises, so nullity is tested with pd.isna alone.
+    """
+    if value is None:
+        return na_rep
+    try:
+        if pd.isna(value):
+            return na_rep
+    except (TypeError, ValueError):
+        pass
+    if isinstance(value, bool):
+        return 'yes' if value else 'no'
+    if isinstance(value, str):
+        return value.strip()
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if decimals is None:
+        units, statistic = data_dictionary.describe_units(variable)
+        if (
+            units == ''
+            and statistic == ''
+            and CODE_PATTERN.search(
+                str(variable),
+            )
+        ):
+            return f'{number:.0f}'
+        digits, separator = decimals_for(units, statistic, number)
+    else:
+        digits, separator = int(decimals), abs(number) >= 1000
+    if separator:
+        return f'{number:,.{digits}f}'
+    return f'{number:.{digits}f}'
+
+
+def canonical(column):
+    """Return the name a variable is reported under across scales."""
+    return VARIABLE_SYNONYMS.get(column, column)
+
+
+def select_variables(frames, variables=None, identifiers=False) -> list:
+    """Return the ordered rows of the summary.
+
+    Rows are the union of the variables of each requested scale, so
+    that nothing a scale reports is silently dropped: a weighted
+    aggregation reports pop_pct_ variables where an unweighted one
+    reports pct_, and the region summary carries covariates the areas
+    do not.  Ordering follows the data dictionary's category order and
+    then first appearance, so that a summary and the region's data
+    dictionary present variables in the same sequence.
+    """
+    excluded = set(data_dictionary.SKIP_COLUMNS)
+    if not identifiers:
+        excluded |= set(data_dictionary.IDENTIFIERS)
+    entries = {}
+    order = 0
+    for frame in frames:
+        label_column = frame.get('label_column')
+        for column in frame['df'].columns:
+            if column in excluded or str(column).startswith('_'):
+                continue
+            if label_column is not None and column == label_column:
+                continue
+            name = canonical(column)
+            if name in entries:
+                continue
+            category, description = data_dictionary.describe_variable(name)
+            entries[name] = {
+                'Category': category,
+                'Indicator': description,
+                'Variable': name,
+                'order': order,
+            }
+            order += 1
+    if isinstance(variables, str) and variables.lower() == 'shared':
+        shared = None
+        for frame in frames:
+            columns = {canonical(c) for c in frame['df'].columns}
+            shared = columns if shared is None else shared & columns
+        entries = {k: v for k, v in entries.items() if k in (shared or set())}
+    elif variables is not None:
+        requested = [_norm(v) for v in variables]
+        lookup = {_norm(k): k for k in entries}
+        entries = {
+            lookup[v]: entries[lookup[v]] for v in requested if v in lookup
+        }
+        for position, key in enumerate(entries):
+            entries[key]['order'] = position
+    rank = {
+        category: i
+        for i, category in enumerate(data_dictionary.CATEGORY_ORDER)
+    }
+    rows = sorted(
+        entries.values(),
+        key=lambda row: (
+            rank.get(row['Category'], len(data_dictionary.CATEGORY_ORDER)),
+            row['order'],
+        ),
+    )
+    # Two variables can share a description (an area's average of a
+    # sample point measure, for example); name them so rows stay
+    # distinguishable.
+    counts = {}
+    for row in rows:
+        counts[row['Indicator']] = counts.get(row['Indicator'], 0) + 1
+    for row in rows:
+        if counts[row['Indicator']] > 1:
+            row['Indicator'] = f"{row['Indicator']} ({row['Variable']})"
+    return rows
+
+
+def table_columns(r, table) -> list:
+    """List a table's columns in their defined order."""
+    df = r.get_df(
+        'SELECT column_name FROM information_schema.columns '
+        f"WHERE table_name = '{table}' ORDER BY ordinal_position",
+    )
+    if df is None or len(df) == 0:
+        return []
+    return df['column_name'].tolist()
+
+
+def count_rows(r, table):
+    """Count a table's rows, returning None where this is not possible."""
+    df = r.get_df(f'SELECT COUNT(*) AS n FROM "{table}"')
+    if df is None or len(df) == 0:
+        return None
+    try:
+        return int(df['n'].iloc[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def _exported_csv(r, table):
+    """Read a scale from its exported CSV, where one has been generated.
+
+    Retrieval can fail with the database unavailable or the analysis
+    incomplete; the CSVs written by generate() carry the same results,
+    so a summary remains possible, as it is for compare().
+    """
+    region_dir = (r.config or {}).get('region_dir')
+    if not region_dir:
+        return None
+    path = f'{region_dir}/{r.codename}_{table}.csv'
+    if os.path.isfile(path):
+        try:
+            return pd.read_csv(path)
+        except Exception as e:
+            print(f'\nNote: {path} could not be read: {e}')
+    return None
+
+
+def _aggregation_settings(config, scale) -> tuple:
+    """Return the (id column, keep_columns) configured for a scale."""
+    aggregation = (config.get('custom_aggregations') or {}).get(
+        scale['aggregation'] or '',
+    )
+    if not aggregation:
+        return (None, None)
+    if str(aggregation.get('data', '')).startswith('OSM:'):
+        return ('osm_id', aggregation.get('keep_columns', ''))
+    return (
+        aggregation.get('id') or 'ogc_fid',
+        aggregation.get('keep_columns', ''),
+    )
+
+
+def _order_clause(columns, label_column, capped):
+    """Order areas by size when capped, and by name when not."""
+    if capped:
+        for column in WEIGHT_COLUMNS:
+            if column in columns:
+                return (f'"{column}" DESC NULLS LAST', column)
+    if label_column is not None:
+        return (f'"{label_column}" ASC NULLS LAST', None)
+    return (None, None)
+
+
+def _label_preference(scale, labels):
+    """Return a column named to head this scale's areas, where given."""
+    if isinstance(labels, str):
+        return labels
+    if isinstance(labels, dict):
+        return labels.get(scale['name']) or labels.get(scale['aggregation'])
+    return None
+
+
+def load_scale(r, scale, max_columns=12, tables=None, labels=None):
+    """Retrieve one scale, as the areas that will become its columns."""
+    tables = r.get_tables() if tables is None else tables
+    config = r.config or {}
+    table = scale['table']
+    id_column, keep_columns = _aggregation_settings(config, scale)
+    id_column = _label_preference(scale, labels) or id_column
+    note = None
+    df = None
+    label_column = None
+    if table in tables:
+        columns = [
+            c
+            for c in table_columns(r, table)
+            if c not in data_dictionary.SKIP_COLUMNS
+            and not str(c).startswith('_')
+        ]
+        if columns:
+            if scale['kind'] != 'city':
+                label_column = resolve_label_column(
+                    columns,
+                    id_column,
+                    keep_columns,
+                )
+            total = count_rows(r, table)
+            capped = total is None or total > max_columns
+            order_by, weight = _order_clause(columns, label_column, capped)
+            # The grid and sample point summaries can hold hundreds of
+            # thousands of rows; project the columns explicitly and
+            # limit in SQL, as get_df drops geometry only once the whole
+            # result has crossed the wire.
+            projection = ', '.join(f'"{c}"' for c in columns)
+            sql = f'SELECT {projection} FROM "{table}"'
+            if order_by:
+                sql = f'{sql} ORDER BY {order_by}'
+            if capped:
+                sql = f'{sql} LIMIT {max_columns}'
+            df = r.get_df(sql)
+            if df is not None and capped and total is not None:
+                ordering = (
+                    f'the {max_columns} largest by {WEIGHT_COLUMNS[weight]}'
+                    if weight
+                    else f'the first {max_columns}'
+                )
+                note = (
+                    f"'{scale['name']}' contains {total:,} areas; showing "
+                    f'{ordering}.  Increase max_columns to show more.'
+                )
+    if df is None:
+        df = _exported_csv(r, table)
+        if df is None:
+            print(
+                f"\nNote: no results were found for the scale "
+                f"'{scale['name']}' ({table}); it has been skipped.  Please "
+                'confirm that analysis and generation have been run.',
+            )
+            return None
+        if scale['kind'] != 'city':
+            label_column = resolve_label_column(
+                df.columns,
+                id_column,
+                keep_columns,
+            )
+            if label_column is not None:
+                df = df.sort_values(label_column, kind='stable')
+        if len(df) > max_columns:
+            note = (
+                f"'{scale['name']}' contains {len(df):,} areas; showing the "
+                f'first {max_columns}.  Increase max_columns to show more.'
+            )
+            df = df.head(max_columns)
+    if len(df) == 0:
+        print(f"\nNote: the scale '{scale['name']}' held no areas.")
+        return None
+    return {
+        'name': scale['name'],
+        'table': table,
+        'kind': scale['kind'],
+        'df': df.reset_index(drop=True),
+        'label_column': label_column,
+        'note': note,
+    }
+
+
+def build_summary(
+    r,
+    scales='region',
+    by=None,
+    variables=None,
+    max_columns=12,
+    identifiers=False,
+    labels=None,
+    include_region=True,
+) -> tuple:
+    """Return the summary as (values DataFrame, notes).
+
+    Rows are indexed by category, plain-language indicator and variable
+    name; columns are one per area, in the order the scales were
+    requested.  Values are returned unformatted, so that they remain
+    available for further calculation.
+    """
+    config = r.config
+    if config is None:
+        raise ValueError(
+            'Could not retrieve the configuration for '
+            f'{getattr(r, "yaml", r.codename)}.  Please ensure the codename '
+            'and file path provided is correct.',
+        )
+    tables = r.get_tables()
+    resolved = resolve_scales(
+        config,
+        tables,
+        normalise_scales(scales, by, include_region),
+    )
+    if not resolved:
+        print(
+            f'\nNo output scales could be resolved for {r.codename}.  Please '
+            'ensure that analysis has been run for this region.',
+        )
+        return (None, [])
+    frames = []
+    notes = []
+    for scale in resolved:
+        frame = load_scale(r, scale, max_columns, tables, labels)
+        if frame is None:
+            continue
+        frames.append(frame)
+        if frame['note']:
+            notes.append(frame['note'])
+    if not frames:
+        return (None, notes)
+    rows = select_variables(frames, variables, identifiers)
+    if not rows:
+        print(f'\nNo summarisable variables were found for {r.codename}.')
+        return (None, notes)
+    keys = []
+    data = {}
+    columns_of = {
+        frame['name']: {canonical(c): c for c in frame['df'].columns}
+        for frame in frames
+    }
+    for frame in frames:
+        df = frame['df']
+        if frame['label_column'] is None:
+            labels = [config.get('name') or r.codename]
+        else:
+            labels = disambiguate(df[frame['label_column']].tolist())
+        for position, label in enumerate(labels):
+            key = (frame['name'], label)
+            keys.append(key)
+            record = df.iloc[position]
+            # a field naming this scale's areas is its column heading; it
+            # may still be a row where another scale reports it as data
+            # (a meshblock's suburb, say), but must not repeat the
+            # heading back beneath it
+            label = canonical(frame['label_column'])
+            data[key] = {
+                entry['Variable']: record.get(
+                    columns_of[frame['name']].get(entry['Variable']),
+                )
+                for entry in rows
+                if entry['Variable'] != label
+                and entry['Variable'] in columns_of[frame['name']]
+            }
+    # An area label can recur across scales (two aggregations may share
+    # an identifier field), so a repeated label is qualified by its scale.
+    counts = {}
+    for _, label in keys:
+        counts[label] = counts.get(label, 0) + 1
+    headers = disambiguate(
+        [
+            label if counts[label] == 1 else f'{label} [{scale_name}]'
+            for scale_name, label in keys
+        ],
+    )
+    index = pd.MultiIndex.from_tuples(
+        [(e['Category'], e['Indicator'], e['Variable']) for e in rows],
+        names=['Category', 'Indicator', 'Variable'],
+    )
+    values = pd.DataFrame(
+        [[data[key].get(entry['Variable']) for key in keys] for entry in rows],
+        index=index,
+        columns=headers,
+    )
+    return (values, notes)
+
+
+def format_frame(values, na_rep='', decimals=None):
+    """Format every value of a summary for display, as text."""
+    variables = values.index.get_level_values('Variable')
+    formatted = [
+        [
+            format_value(variables[position], value, na_rep, decimals)
+            for value in values.iloc[position]
+        ]
+        for position in range(len(values))
+    ]
+    return pd.DataFrame(
+        formatted,
+        index=values.index,
+        columns=values.columns,
+    )
+
+
+def _terminal_width(width=None) -> int:
+    """Return the width to render a text table within."""
+    if width is None:
+        try:
+            from _utils import get_terminal_columns
+
+            width = get_terminal_columns()
+        except Exception:
+            width = 80
+    return max(int(width), 40)
+
+
+def _panel(headers, widths, available) -> list:
+    """Group columns into panels that each fit the available width."""
+    panels = []
+    current = []
+    used = 0
+    for header, size in zip(headers, widths):
+        cost = size + 2
+        if current and used + cost > available:
+            panels.append(current)
+            current = []
+            used = 0
+        current.append(header)
+        used += cost
+    if current:
+        panels.append(current)
+    return panels
+
+
+def render_text(formatted, width=None, notes=(), title=None) -> str:
+    """Render the summary as a fixed width table of labelled rows.
+
+    Columns are rendered in panels where they exceed the width
+    available, repeating the indicator labels for each, rather than
+    wrapping mid-row.  Note that print_autobreak() cannot be used for
+    the table itself: it word wraps, which would destroy the alignment.
+    """
+    width = _terminal_width(width)
+    indicators = [
+        str(label) for label in formatted.index.get_level_values('Indicator')
+    ]
+    categories = [
+        str(label) for label in formatted.index.get_level_values('Category')
+    ]
+    limit = 22
+    shortened = []
+    legend = []
+    for header in [str(column) for column in formatted.columns]:
+        if len(header) > limit:
+            short = f'{header[: limit - 1]}.'
+            legend.append(f'{short}  {header}')
+        else:
+            short = header
+        shortened.append(short)
+    shortened = disambiguate(shortened)
+    widths = {
+        header: max(
+            len(header),
+            max(
+                (len(str(v)) for v in formatted[column]),
+                default=0,
+            ),
+        )
+        for header, column in zip(shortened, formatted.columns)
+    }
+    label_width = min(
+        max((len(label) for label in indicators), default=20),
+        max(24, int(width * 0.45)),
+    )
+    panels = _panel(
+        shortened,
+        [widths[h] for h in shortened],
+        max(width - label_width - 2, 20),
+    )
+    lines = []
+    if title:
+        lines.extend([title, '=' * min(len(title), width)])
+    for position, panel in enumerate(panels):
+        if position > 0:
+            lines.append('')
+            lines.append('(continued)')
+        header_line = (
+            ' ' * label_width
+            + '  '
+            + '  '.join(header.rjust(widths[header]) for header in panel)
+        )
+        lines.append('')
+        lines.append(header_line)
+        lines.append('-' * min(len(header_line), width))
+        category = None
+        for row in range(len(formatted)):
+            if categories[row] != category:
+                category = categories[row]
+                lines.append('')
+                lines.append(category)
+            cells = [
+                str(formatted.iloc[row][formatted.columns[shortened.index(h)]])
+                for h in panel
+            ]
+            wrapped = textwrap.wrap(indicators[row], label_width) or ['']
+            lines.append(
+                wrapped[0].ljust(label_width)
+                + '  '
+                + '  '.join(
+                    cell.rjust(widths[header])
+                    for cell, header in zip(cells, panel)
+                ),
+            )
+            for continuation in wrapped[1:]:
+                lines.append(continuation.ljust(label_width))
+    for note in list(notes) + legend:
+        lines.append('')
+        lines.extend(textwrap.wrap(note, width))
+    return '\n'.join(lines)
+
+
+def _escape(text) -> str:
+    """Escape a value for inclusion in a markdown table cell."""
+    return (
+        str(text)
+        .replace('|', '\\|')
+        .replace('\n', ' ')
+        .replace('\r', ' ')
+        .strip()
+    )
+
+
+def to_markdown(formatted, title=None, notes=(), group=True) -> str:
+    """Render the summary as a markdown table.
+
+    Written directly rather than with DataFrame.to_markdown(), which
+    requires tabulate; that is present in the Earth Engine image but not
+    the standard one, so relying on it would fail for most users.
+    """
+    columns = [str(column) for column in formatted.columns]
+    lines = []
+    if title:
+        lines.extend([f'## {title}', ''])
+    lines.append('| ' + ' | '.join(['Indicator'] + columns) + ' |')
+    lines.append('| ' + ' | '.join([':---'] + ['---:'] * len(columns)) + ' |')
+    category = None
+    for row in range(len(formatted)):
+        row_category, indicator, _ = formatted.index[row]
+        if group and row_category != category:
+            category = row_category
+            lines.append(
+                '| '
+                + ' | '.join(
+                    [f'**{_escape(category)}**'] + [''] * len(columns),
+                )
+                + ' |',
+            )
+        lines.append(
+            '| '
+            + ' | '.join(
+                [_escape(indicator)]
+                + [_escape(value) for value in formatted.iloc[row]],
+            )
+            + ' |',
+        )
+    for note in notes:
+        lines.extend(['', f'*{note}*'])
+    return '\n'.join(lines)
+
+
+def _in_notebook() -> bool:
+    """Report whether this is running in a notebook."""
+    try:
+        from IPython import get_ipython
+
+        shell = get_ipython()
+        return (
+            shell is not None
+            and shell.__class__.__name__ == 'ZMQInteractiveShell'
+        )
+    except Exception:
+        return False
+
+
+def _display_markdown(text) -> None:
+    """Display markdown, rendered where a notebook can render it."""
+    if _in_notebook():
+        try:
+            from IPython.display import Markdown, display
+
+            display(Markdown(text))
+            return
+        except Exception:
+            pass
+    print(text)
+
+
+def save_summary(r, values, markdown_text, save, title=None, notes=()):
+    """Save the summary, as markdown or (with a .csv path) as values."""
+    if isinstance(save, str):
+        path = save
+    else:
+        stamp = datetime.now().strftime('%Y-%m-%d_%H%M')
+        region_dir = (r.config or {}).get('region_dir', '.')
+        path = f'{region_dir}/{r.codename}_indicator_summary_{stamp}.md'
+    if path.lower().endswith('.csv'):
+        values.to_csv(path)
+    else:
+        with open(path, 'w', encoding='utf-8') as file:
+            file.write(markdown_text)
+            file.write('\n')
+    print(f'\nIndicator summary saved as {os.path.basename(path)}')
+    return path
+
+
+def indicator_summary(
+    r,
+    scales='region',
+    by=None,
+    variables=None,
+    max_columns=12,
+    decimals=None,
+    identifiers=False,
+    labels=None,
+    include_region=True,
+    markdown=False,
+    save=False,
+    display=True,
+    na_rep='',
+):
+    """Summarise a region's indicators as a tidy, labelled table.
+
+    Returns the formatted table, or the markdown text where markdown is
+    requested.  build_summary() returns the same table unformatted,
+    where the values are wanted for further calculation.
+    """
+    values, notes = build_summary(
+        r,
+        scales=scales,
+        by=by,
+        variables=variables,
+        max_columns=max_columns,
+        identifiers=identifiers,
+        labels=labels,
+        include_region=include_region,
+    )
+    if values is None:
+        return None
+    formatted = format_frame(values, na_rep=na_rep, decimals=decimals)
+    name = (r.config or {}).get('name') or r.codename
+    title = f'Indicator summary: {name} ({r.codename})'
+    markdown_text = None
+    if markdown or (
+        isinstance(save, str) and not save.lower().endswith('.csv')
+    ):
+        markdown_text = to_markdown(formatted, title=title, notes=notes)
+    elif save is True:
+        markdown_text = to_markdown(formatted, title=title, notes=notes)
+    if display:
+        if markdown:
+            _display_markdown(markdown_text)
+        elif _in_notebook():
+            # the returned table is rendered by the notebook itself
+            for note in notes:
+                print(note)
+        else:
+            print(render_text(formatted, notes=notes, title=title))
+    if save:
+        save_summary(r, values, markdown_text, save, title, notes)
+    return markdown_text if markdown else formatted
+
+
+def main():
+    """Summarise indicators for a region named on the commandline."""
+    if len(sys.argv) < 2:
+        sys.exit(
+            'Summarise a study region\'s indicators as a tidy table of '
+            'plain-language rows, with a column per area.\n\nUsage:\n  '
+            'python subprocesses/indicator_summary.py <codename> [scale ...] '
+            '[--markdown] [--save]\n\nFor example:\n  python '
+            'subprocesses/indicator_summary.py ES_Las_Palmas_2025 region '
+            'school_districts_grid_pop --markdown',
+        )
+    import ghsci
+
+    arguments = sys.argv[1:]
+    options = [a for a in arguments if a.startswith('--')]
+    positional = [a for a in arguments if not a.startswith('--')]
+    r = ghsci.Region(positional[0])
+    scales = positional[1:] or ['region']
+    return indicator_summary(
+        r,
+        scales=scales,
+        markdown='--markdown' in options,
+        save='--save' in options,
+    )
+
+
+if __name__ == '__main__':
+    # allow for running from the process folder or subprocesses
+    if os.path.basename(os.getcwd()) == 'subprocesses':
+        os.chdir('..')
+    sys.path.append(os.path.abspath('./subprocesses'))
+    main()

--- a/process/tests/tests.py
+++ b/process/tests/tests.py
@@ -449,6 +449,89 @@ class tests(unittest.TestCase):
                 with self.assertRaises(SystemExit):
                     load(boundary, returncode)
 
+    def test_0_7a_custom_aggregation_output_names(self):
+        """Aggregation output names do not depend on the weight variable."""
+        from subprocesses import ghsci
+        from subprocesses._12_aggregation import resolve_output_names
+
+        indicators = ghsci.indicators
+        neighbourhood = indicators['output']['neighbourhood_variables']
+        city = indicators['output']['city_variables']
+        extra = indicators['output']['extra_unweighted_vars']
+
+        def names(agg_kind, weighted):
+            return [
+                output
+                for _, output, _ in resolve_output_names(
+                    indicators,
+                    agg_kind,
+                    weighted,
+                )
+            ]
+
+        # a weighted areal aggregation reports the region level variable
+        # names, whichever variable did the weighting: the weight is
+        # reported as pop_est, not encoded in the column names, so that a
+        # population grid weighted aggregation and one weighted by a census
+        # count of the same areas may be compared row for row
+        self.assertEqual(names('grid', True), city)
+        self.assertEqual(names('area', True), city)
+        # the unweighted neighbourhood estimates accompany them, so that the
+        # weighted and unweighted values remain distinguishable; every one
+        # of them is available to be reported alongside
+        for variable in extra:
+            self.assertIn(variable, neighbourhood)
+            self.assertNotIn(
+                variable,
+                city,
+                'an unweighted extra must not collide with a weighted column',
+            )
+
+        # an unweighted areal aggregation reports the neighbourhood names as
+        # they stand.  These values have already been scaled by the summary
+        # they are drawn from, so they are not scaled again
+        for agg_kind in ['grid', 'area']:
+            with self.subTest(agg_kind=agg_kind):
+                self.assertEqual(names(agg_kind, False), neighbourhood)
+                self.assertEqual(
+                    {
+                        scale
+                        for _, _, scale in resolve_output_names(
+                            indicators,
+                            agg_kind,
+                            False,
+                        )
+                    },
+                    {1.0},
+                )
+                # no 'avg_' prefixed variant of a neighbourhood variable
+                self.assertFalse(
+                    [
+                        x
+                        for x in names(agg_kind, False)
+                        if x.startswith('avg_')
+                    ],
+                )
+
+        # sample points are read under their own names and take the
+        # neighbourhood names; their accessibility measures are proportions,
+        # so those alone are scaled to percentages
+        self.assertEqual(names('point', False), neighbourhood)
+        for source, output, scale in resolve_output_names(
+            indicators,
+            'point',
+            False,
+        ):
+            with self.subTest(source=source):
+                self.assertIn(
+                    source,
+                    indicators['output']['sample_point_variables'],
+                )
+                self.assertEqual(
+                    scale,
+                    100.0 if output.startswith('pct_') else 1.0,
+                )
+
     def test_0_8_data_key_synonym(self):
         """The path key is 'data', with 'data_dir' accepted as a synonym."""
         from subprocesses import ghsci
@@ -784,6 +867,287 @@ class tests(unittest.TestCase):
                 # these descriptions; an 'Other fields' fallback means a
                 # naming convention has drifted from its describer
                 self.assertNotEqual(category, 'Other fields')
+
+    def test_0_14_indicator_summary_scales(self):
+        """Summary scales resolve by alias, aggregation name and table."""
+        import indicator_summary as isum
+
+        config = {
+            'city_summary': 'indicators_region',
+            'grid_summary': 'indicators_grid_100m',
+            'point_summary': 'indicators_sample_points',
+            'custom_aggregations': {
+                'suburbs': {'data': 'x.zip', 'id': 'SAL_NAME21'},
+                'buildings osm': {'data': 'OSM:building is not NULL'},
+            },
+        }
+        tables = [
+            'indicators_region',
+            'indicators_grid_100m',
+            'indicators_suburbs',
+            'indicators_buildings_osm',
+        ]
+        self.assertEqual(
+            isum.normalise_scales('region', ['suburbs', 'suburbs']),
+            ['region', 'suburbs'],
+        )
+        self.assertEqual(isum.normalise_scales(None), ['region'])
+        self.assertEqual(
+            isum.normalise_scales(['region', ['suburbs']]),
+            ['region', 'suburbs'],
+        )
+        # the region summary is the reference each area is read
+        # against, so it heads the columns unless declined
+        self.assertEqual(
+            isum.normalise_scales('suburbs'),
+            ['region', 'suburbs'],
+        )
+        self.assertEqual(
+            isum.normalise_scales('suburbs', include_region=False),
+            ['suburbs'],
+        )
+        # not prepended where it was asked for in another position
+        self.assertEqual(
+            isum.normalise_scales(['suburbs', 'city']),
+            ['suburbs', 'city'],
+        )
+        resolved = isum.resolve_scales(
+            config,
+            tables,
+            ['Region', 'SUBURBS', 'buildings-osm', 'indicators_grid_100m'],
+        )
+        self.assertEqual(
+            [scale['table'] for scale in resolved],
+            [
+                'indicators_region',
+                'indicators_suburbs',
+                'indicators_buildings_osm',
+                'indicators_grid_100m',
+            ],
+        )
+        # an unrecognised scale is reported and skipped, not raised
+        self.assertEqual(isum.resolve_scales(config, tables, ['nope']), [])
+        # a custom aggregation may also be the configured population
+        # grid, in which case both names identify the same table
+        shared = dict(config, grid_summary='indicators_suburbs')
+        self.assertEqual(
+            len(isum.resolve_scales(shared, tables, ['grid', 'suburbs'])),
+            1,
+        )
+
+    def test_0_14a_indicator_summary_labels(self):
+        """Areas are headed by the identifier configured for them."""
+        import indicator_summary as isum
+
+        # the aggregation SQL selects the identifier unquoted, so a
+        # configured 'SAL_NAME21' is the column 'sal_name21'
+        self.assertEqual(
+            isum.resolve_label_column(
+                ['sal_name21', 'area_sqkm'],
+                'SAL_NAME21',
+                'SAL_NAME21',
+            ),
+            'sal_name21',
+        )
+        # a surrogate identifier numbers areas rather than naming them,
+        # so a retained boundary attribute is preferred
+        self.assertEqual(
+            isum.resolve_label_column(
+                ['ogc_fid', 'mb_cat21', 'area_sqkm'],
+                'ogc_fid',
+                'MB_CAT21',
+            ),
+            'mb_cat21',
+        )
+        self.assertEqual(
+            isum.resolve_label_column(['ogc_fid', 'area_sqkm'], None, None),
+            'ogc_fid',
+        )
+        self.assertEqual(
+            isum.disambiguate(['Woy Woy', 'Woy Woy', None, '']),
+            ['Woy Woy', 'Woy Woy (2)', '(unnamed)', '(unnamed) (2)'],
+        )
+
+    def test_0_14b_indicator_summary_rounding(self):
+        """Values are rounded according to what they measure."""
+        import indicator_summary as isum
+        import pandas as pd
+
+        cases = [
+            ('pop_pct_access_500m_fresh_food_market_score', 62.4487, '62.4'),
+            ('pop_est', 12345.678, '12,346'),
+            ('intersection_count', 1234, '1,234'),
+            ('pop_per_sqkm', 4523.24, '4,523'),
+            ('area_sqkm', 3.14159, '3.14'),
+            ('local_walkability', -0.1234, '-0.12'),
+            ('local_daily_living', 2.345, '2.35'),
+            ('year', 2025, '2025'),
+            ('avg_walk_dist_supermarket', 843.77, '844'),
+            # a postcode retained from boundary data is a code, not a
+            # quantity, and must not be grouped into thousands
+            ('cod_postal', 35010, '35010'),
+        ]
+        for variable, value, expected in cases:
+            with self.subTest(variable=variable, value=value):
+                self.assertEqual(isum.format_value(variable, value), expected)
+        # a pyarrow backed frame reports a null as pd.NA, which is not
+        # an instance of float and cannot be truth tested
+        for missing in [None, float('nan'), pd.NA]:
+            with self.subTest(missing=repr(missing)):
+                self.assertEqual(isum.format_value('pop_est', missing), '')
+        self.assertEqual(isum.format_value('pop_est', pd.NA, na_rep='-'), '-')
+        self.assertEqual(
+            isum.format_value('study_region', ' Woy Woy '),
+            'Woy Woy',
+        )
+        self.assertEqual(
+            isum.format_value('local_walkability', 3.14159, decimals=3),
+            '3.142',
+        )
+
+    def test_0_14c_indicator_summary_rows(self):
+        """Rows are the union of the scales, labelled and ordered."""
+        import data_dictionary as dd
+        import indicator_summary as isum
+        import pandas as pd
+
+        frames = [
+            {
+                'name': 'region',
+                'df': pd.DataFrame(
+                    [
+                        {
+                            'study_region': 'A',
+                            'Population estimate': 10.0,
+                            'pop_walkability': 1.0,
+                            'geom': None,
+                        },
+                    ],
+                ),
+                'label_column': None,
+            },
+            {
+                'name': 'suburbs',
+                'df': pd.DataFrame(
+                    [
+                        {
+                            'sal_name21': 'B',
+                            'pop_est': 5.0,
+                            'local_walkability': 0.5,
+                            '_private': 1,
+                        },
+                    ],
+                ),
+                'label_column': 'sal_name21',
+            },
+        ]
+        rows = isum.select_variables(frames)
+        variables = [row['Variable'] for row in rows]
+        # the region summary's display-style column names report the
+        # same measures as an aggregation's lower case names
+        self.assertIn('pop_est', variables)
+        self.assertNotIn('Population estimate', variables)
+        for excluded in ['geom', '_private', 'study_region', 'sal_name21']:
+            with self.subTest(excluded=excluded):
+                self.assertNotIn(excluded, variables)
+        # the union, so that a variable of either scale is reported
+        self.assertIn('pop_walkability', variables)
+        self.assertIn('local_walkability', variables)
+        self.assertTrue(all(row['Indicator'] for row in rows))
+        rank = {category: i for i, category in enumerate(dd.CATEGORY_ORDER)}
+        ranks = [
+            rank.get(row['Category'], len(dd.CATEGORY_ORDER)) for row in rows
+        ]
+        self.assertEqual(ranks, sorted(ranks))
+        shared = isum.select_variables(frames, variables='shared')
+        self.assertEqual([row['Variable'] for row in shared], ['pop_est'])
+
+    def test_0_14d_indicator_summary_markdown(self):
+        """Markdown tables are rendered without the tabulate dependency."""
+        import indicator_summary as isum
+        import pandas as pd
+
+        index = pd.MultiIndex.from_tuples(
+            [('Walkability', 'Walk | index', 'pop_walkability')],
+            names=['Category', 'Indicator', 'Variable'],
+        )
+        formatted = pd.DataFrame(
+            [['1.20', '0.30']],
+            index=index,
+            columns=['A', 'B'],
+        )
+        markdown = isum.to_markdown(formatted, title='Test')
+        rows = [line for line in markdown.split('\n') if line.startswith('|')]
+        # header, alignment, category heading, and one value row
+        self.assertEqual(len(rows), 4)
+        for row in rows:
+            with self.subTest(row=row):
+                self.assertEqual(row.count('|') - row.count('\\|'), 4)
+        self.assertIn('---:', rows[1])
+        self.assertIn('**Walkability**', rows[2])
+        self.assertIn('Walk \\| index', rows[3])
+        # DataFrame.to_markdown() requires tabulate, which is installed
+        # in the Earth Engine image but not the standard one
+        self.assertNotIn('tabulate', sys.modules)
+
+    def test_0_14e_indicator_summary_text_width(self):
+        """Summaries too wide for the terminal are rendered in panels."""
+        import indicator_summary as isum
+        import pandas as pd
+
+        index = pd.MultiIndex.from_tuples(
+            [('Walkability', 'Average walkability index', 'pop_walkability')],
+            names=['Category', 'Indicator', 'Variable'],
+        )
+        formatted = pd.DataFrame(
+            [[f'{i}.00' for i in range(20)]],
+            index=index,
+            columns=[f'Area {i}' for i in range(20)],
+        )
+        text = isum.render_text(formatted, width=60)
+        for line in text.split('\n'):
+            with self.subTest(line=line):
+                self.assertLessEqual(len(line), 60)
+        # the indicator labels are repeated for each panel of columns
+        self.assertGreater(text.count('(continued)'), 0)
+        self.assertEqual(
+            text.count('Average walkability index'),
+            text.count('(continued)') + 1,
+        )
+
+    def test_0_14f_indicator_summary_without_results(self):
+        """A region without results is reported, rather than raising."""
+        import types
+
+        import indicator_summary as isum
+
+        config = {
+            'city_summary': 'indicators_region',
+            'region_dir': '/nonexistent',
+        }
+        without_tables = types.SimpleNamespace(
+            codename='test',
+            config=config,
+            get_tables=lambda: [],
+            get_df=lambda *args, **kwargs: None,
+        )
+        self.assertIsNone(isum.indicator_summary(without_tables))
+        # get_df reports its own errors and returns None
+        without_data = types.SimpleNamespace(
+            codename='test',
+            config=config,
+            get_tables=lambda: ['indicators_region'],
+            get_df=lambda *args, **kwargs: None,
+        )
+        self.assertIsNone(isum.indicator_summary(without_data))
+        unloaded = types.SimpleNamespace(
+            codename='test',
+            config=None,
+            get_tables=lambda: [],
+            get_df=lambda *args, **kwargs: None,
+        )
+        with self.assertRaises(ValueError):
+            isum.indicator_summary(unloaded)
 
     def test_0_21_blue_space_and_open_space_variants(self):
         """Blue space criteria, and the public open space node layer variants."""
@@ -1789,6 +2153,35 @@ areas_of_interest:
         """Generate resources for example region."""
         r = ghsci.example()
         r.generate()
+
+    def test_6a_example_indicator_summary(self):
+        """Summarise indicators for the analysed example region."""
+        import indicator_summary as isum
+
+        r = ghsci.example()
+        if 'indicators_region' not in r.get_tables():
+            self.skipTest('Analysis has not been run for the example region')
+        summary = r.indicator_summary(display=False)
+        self.assertIsNotNone(summary)
+        self.assertEqual(summary.shape[1], 1)
+        self.assertGreater(len(summary), 10)
+        # every row is labelled in plain language, not by variable name
+        for category, indicator, variable in summary.index:
+            with self.subTest(variable=variable):
+                self.assertTrue(indicator)
+                self.assertTrue(category)
+        markdown = isum.to_markdown(summary)
+        self.assertIn('| Indicator |', markdown)
+        # a custom aggregation reports one column per area
+        aggregations = list(r.config.get('custom_aggregations') or {})
+        if aggregations:
+            areas = r.indicator_summary(
+                'region',
+                aggregations[:1],
+                max_columns=3,
+                display=False,
+            )
+            self.assertGreater(areas.shape[1], 1)
 
     def test_7_sensitivity(self):
         """Test sensitivity analysis of urban intersection parameter."""


### PR DESCRIPTION
Adds an `r.indicator_summary()` function that can output summaries with plain language indicator descriptions for multiple processed regions, e.g.

```python
r.indicator_summary(scales=['suburbs'],markdown=True)
```

could ouput the following directly usable output, showing overall region result and a 'suburbs' custom aggregation, displayed in markdown format:

<details>

<summary>click to view markdown summary table</summary>

## Indicator summary: Woy Woy Peninsula (AU_Woy_Woy_2025_MB)

| Indicator | Woy Woy Peninsula | Blackwall (NSW) | Booker Bay | Ettalong Beach | Pearl Beach | Umina Beach | Woy Woy |
| :--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| **Derived study region statistics** |  |  |  |  |  |  |  |
| Area (km²) | 17.54 | 1.14 | 0.49 | 1.78 | 1.26 | 6.99 | 5.88 |
| Population estimate, as per configured population data source | 37,473 | 1,941 | 1,440 | 5,124 | 478 | 17,242 | 10,927 |
| Population per km² | 2,136 | 1,698 | 2,914 | 2,883 | 380.2 | 2,468 | 1,858 |
| Intersection count (following consolidation based on intersection tolerance parameter in region configuration) | 1,086 | 86 | 24 | 165 | 35 | 441 | 311 |
| Intersections per km² | 61.9 | 75.2 | 48.6 | 92.8 | 27.8 | 63.1 | 52.9 |
| **Analytical statistics** |  |  |  |  |  |  |  |
| Sample points used in this analysis (generated along pedestrian network for populated grid areas) | 7,774 |  |  |  |  |  |  |
| Count of population grid cells associated with this area |  | 41 | 31 | 99 | 16 | 224 | 144 |
| **Indicator estimates: access (walking)** |  |  |  |  |  |  |  |
| Percentage of population with access within 500 m of a fresh food market / supermarket (source: OpenStreetMap or custom data) (population weighted) | 16.7 | 0.0 | 17.3 | 26.7 | 0.0 | 21.6 | 7.9 |
| Percentage of population with access within 500 m of a convenience store (source: OpenStreetMap or custom data) (population weighted) | 19.3 | 30.1 | 0.0 | 26.7 | 0.0 | 22.4 | 12.3 |
| Percentage of population with access within 500 m of any public transport stop (source: OpenStreetMap or custom data) (population weighted) | 92.8 | 100.0 | 98.8 | 98.1 | 92.4 | 90.0 | 92.7 |
| Percentage of population with access within 500 m of any public open space (source: OpenStreetMap) (population weighted) | 81.8 | 96.1 | 39.2 | 85.3 | 57.9 | 79.8 | 87.4 |
| Percentage of population with access within 500 m of a public open space larger than 1.5 hectares (source: OpenStreetMap) (population weighted) | 39.1 | 37.1 | 5.9 | 57.8 | 24.9 | 16.5 | 71.4 |
| Percentage of population with access within 500 m of any public transport stop (source: GTFS) (population weighted) | 93.8 | 100.0 | 98.8 | 98.1 | 92.4 | 90.1 | 95.7 |
| Percentage of population with access within 500 m of a public transport stop with average daytime weekday service frequency of 30 minutes or better (source: GTFS) (population weighted) | 71.1 | 79.4 | 87.0 | 90.5 | 0.0 | 67.0 | 68.0 |
| Percentage of population with access within 500 m of a public transport stop with average daytime weekday service frequency of 20 minutes or better (source: GTFS) (population weighted) | 46.8 | 20.1 | 87.0 | 61.2 | 0.0 | 40.8 | 51.1 |
| Percentage of population with access within 500 m of any public transport stop (best result of GTFS and OpenStreetMap/custom sources) (population weighted) | 93.8 | 100.0 | 98.8 | 98.1 | 92.4 | 90.2 | 95.7 |
| **Indicator estimates: walkability** |  |  |  |  |  |  |  |
| Average walkable neighbourhood population density (population per km²; population weighted) | 2,755 | 2,812 | 2,787 | 2,791 | 537.8 | 2,909 | 2,579 |
| Average walkable neighbourhood intersection density (intersections per km²; population weighted) | 97.2 | 108.4 | 79.0 | 116.3 | 41.4 | 98.8 | 88.4 |
| Average daily living score (/3; population weighted) | 1.30 | 1.30 | 1.16 | 1.52 | 0.92 | 1.34 | 1.16 |
| Average walkability index (population weighted) | -0.10 | 0.51 | -1.02 | 1.10 | -7.13 | 0.32 | -0.99 |
| Average walkable neighbourhood population density (population per km²) of sample points in this area | 2,682 | 2,839 | 2,764 | 2,791 | 743.8 | 2,862 | 2,575 |
| Average walkable neighbourhood intersection density (intersections per km²) of sample points in this area | 98.9 | 109.2 | 81.1 | 115.7 | 47.5 | 103.4 | 90.1 |
| Average daily living score (/3) of sample points in this area | 1.38 | 1.26 | 1.25 | 1.55 | 0.95 | 1.42 | 1.21 |
| Average walkability index of sample points in this area | -0.04 | 0.54 | -0.85 | 1.12 | -6.45 | 0.54 | -0.85 |

</details>

```
r.indicator_summary(
    scales='region',        # scale(s) to summarise, in column order
    by=None,                # further scales, so a list can be passed positionally
    variables=None,         # None = union of all scales; 'shared' = intersection; or a list
    max_columns=12,         # cap on areas per scale
    decimals=None,          # override the per-variable rounding
    labels=None,            # column-heading field: a name, or {scale: name}
    include_region=True,    # prepend the region summary column
    markdown=False,         # return markdown instead of the formatted frame
    save=False,             # True, or a path ('.md' or '.csv')
    display=True,           # print on call
)
```

Scales and by are concatenated and flattened --- called in this way:

r.indicator_summary()                                     # region only
r.indicator_summary('suburbs')                            # region, then each suburb
r.indicator_summary('region', ['suburbs', 'meshblocks'])  # region, suburbs, meshblocks

A scale may be named by alias (region/city, grid, sample points), by custom aggregation name as written in the config (suburbs, buildings osm), or by table name (indicators_suburbs) — matched case- and separator-insensitively. The region column is prepended unless it was named in another position or include_region=False. Unrecognised names are reported with the valid options and skipped, not raised. Scales are de-duplicated by resolved table, so 'grid' and a custom aggregation serving as custom_population yield one set of columns, not two.

Column headings come from the aggregation's configured id (matched case-insensitively, since the aggregation SQL selects it unquoted and PostgreSQL folds it to lower case), falling back to the first non-surrogate keep_columns entry, then ogc_fid. Override with labels='denominaci' or labels={'meshblocks': 'MB_CAT21'}. Duplicates are numbered; a label recurring across scales is qualified with its scale name.

Rows are the union across scales, ordered by the data dictionary's CATEGORY_ORDER then first appearance — the same rule as the region's data dictionary, so both read in the same sequence. Geometry, private and identifier columns are dropped, as is each scale's own heading field. Values round by what they measure, from the units and statistic describe_units() reports: percentages 1 dp, counts and populations with thousands separators, areas 2 dp, indices and scores 2 dp, distances whole metres.

Returns the formatted DataFrame (MultiIndex rows of Category / Indicator / Variable; string cells), or the markdown string with markdown=True. build_summary(r, ...) returns the same table unformatted for further calculation. With display=True it prints a fixed-width table panelled to the terminal width; in a notebook it prints only the notes and lets the returned frame render.

Worth noting:

- Missing results are reported and return None rather than raising; retrieval falls back to the CSVs written by generate() when the database is unavailable, as compare() does.
- High-cardinality scales are capped at max_columns, ordered by pop_est or a unit count, with a note saying what was shown — so 'grid' gives 12 columns, not 39,000.
- Markdown is written by hand: tabulate is in the Earth Engine image only, so DataFrame.to_markdown() would work for some users and ImportError for the rest. A test guards this.
- Also runs standalone: /env/bin/python subprocesses/indicator_summary.py <codename> [scale ...] [--markdown] [--save].